### PR TITLE
Fix: Waveshare ESP32-S3 LCD7 Display Rotation

### DIFF
--- a/custom_components/reterminal_dashboard/frontend/hardware/waveshare-esp32-s3-touch-lcd-7.yaml
+++ b/custom_components/reterminal_dashboard/frontend/hardware/waveshare-esp32-s3-touch-lcd-7.yaml
@@ -111,7 +111,7 @@ display:
   - platform: mipi_rgb
     model: ESP32-S3-TOUCH-LCD-7-800X480
     id: my_display
-    rotation: 90
+    rotation: 0
     update_interval: never
     auto_clear_enabled: false
     color_order: RGB


### PR DESCRIPTION
Tested on a Waveshare ESP32-S3-Touch-LCD-7, and while it does generally work, the image is rotated. 
Changing the rotation: 90 to 0 fixes the issue. 


_I am not exactly a programmer, and this is my first ever pull request, so if I did anything wrong, please feel free to ignore the issue. I just wanted to add my 2 cents on the project. ;)_ 