### PR TITLE
Remove captive portal instructions from waveshare LCD config

### DIFF
--- a/custom_components/esphome_designer/frontend/hardware/waveshare-esp32-s3-touch-lcd-7.yaml
+++ b/custom_components/esphome_designer/frontend/hardware/waveshare-esp32-s3-touch-lcd-7.yaml
@@ -33,11 +33,6 @@
 #         - System sections (esphome, esp32, psram, etc.) are auto-commented
 #           to avoid conflicts with your existing setup.
 #
-# CAPTIVE PORTAL:
-#         - If WiFi connection fails, look for a hotspot named:
-#           "Waveshare-7-Inch"
-#         - Connect and go to http://192.168.4.1 to configure WiFi.
-#
 # ============================================================================
 
 esphome:


### PR DESCRIPTION
Removed:
```
# CAPTIVE PORTAL:
#         - If WiFi connection fails, look for a hotspot named:
#           "Waveshare-7-Inch"
#         - Connect and go to http://192.168.4.1 to configure WiFi.
```
How can you now the SSID will be that when the code do not include ap: block? And how do you know the IP will be that?

Does not make sense to have these instructions.