### PR TITLE
Add hardware profile for Waveshare ESP32-C6 LCD 1.47"

### DIFF
--- a/custom_components/reterminal_dashboard/frontend/hardware/waveshare-esp32-c6-lcd-1.47.yaml
+++ b/custom_components/reterminal_dashboard/frontend/hardware/waveshare-esp32-c6-lcd-1.47.yaml
@@ -204,5 +204,4 @@ display:
     model: Waveshare 1.47in 172X320
     id: my_display
     rotation: 0
-    lambda: |-
     # __LAMBDA_PLACEHOLDER__


### PR DESCRIPTION
[https://www.waveshare.com/esp32-c6-lcd-1.47.htm](https://www.waveshare.com/esp32-c6-lcd-1.47.htm)