### PR TITLE
support local sensors in the weather icon widget

### DIFF
--- a/custom_components/esphome_designer/frontend/features/weather_icon/plugin.js
+++ b/custom_components/esphome_designer/frontend/features/weather_icon/plugin.js
@@ -50,7 +50,9 @@ const exportDoc = (w, context) => {
     if (entityId) {
         const attributePath = (p.attribute || "").trim();
         const rootAttr = (attributePath.includes(".") || attributePath.includes("[")) ? attributePath.split(/[.[]/)[0] : attributePath;
-        const safeId = makeSafeId(entityId, rootAttr, "_txt");
+        // A local sensor already exists on the device, so reference it directly
+        // instead of the id generated for a Home Assistant text sensor.
+        const safeId = p.is_local_sensor ? entityId : makeSafeId(entityId, rootAttr, "_txt");
 
         // Centering logic
         const centerX = Math.round(w.x + w.width / 2);
@@ -87,6 +89,8 @@ const onExportTextSensors = (context) => {
     const weatherEntities = new Set();
     for (const w of widgets) {
         if (w.type !== "weather_icon") continue;
+        // Local sensors are declared on the device, so no HA sensor is exported.
+        if (w.props?.is_local_sensor) continue;
         const entityId = (w.entity_id || w.props?.weather_entity || "weather.forecast_home").trim();
         const attribute = (w.props?.attribute || "").trim();
         const mqttTopic = (w.props?.mqtt_topic || "").trim();

--- a/custom_components/esphome_designer/frontend/features/weather_icon/properties.js
+++ b/custom_components/esphome_designer/frontend/features/weather_icon/properties.js
@@ -54,6 +54,7 @@ export function renderWeatherIconProperties(panel, widget) {
             updateProp("size", isNaN(n) ? 48 : n);
         });
         panel.addCheckbox("Fit icon to frame", !!props.fit_icon_to_frame, (/** @type {boolean} */ v) => updateProp("fit_icon_to_frame", v));
+        panel.addCheckbox("Local / On-Device Sensor", !!props.is_local_sensor, (/** @type {boolean} */ v) => updateProp("is_local_sensor", v));
         panel.addColorSelector("Icon Color", props.color || "theme_auto", null, (/** @type {string} */ v) => updateProp("color", v));
         panel.endSection();
 


### PR DESCRIPTION
I'm building a Homey app that drives an ESPHome display, and I hit a wall with the weather icon widget.

Homey has no equivalent of ESPHome's `platform: homeassistant` sensors, so nothing can pull state onto the node. Instead I push values the other way: Homey calls user-defined API actions over the native API, and those write into template sensors that live on the device. Designer already supports this beautifully for sensor_text via the "Local / On-Device Sensor" checkbox, and the reTerminal E1003 profile generates the hardware YAML for me, so most of the layout just works.

The weather icon is the one widget that doesn't. It always exports a `platform: homeassistant` text sensor and references the generated `<entity>_txt` id, with no way to opt out. On a node with no Home Assistant behind it that block is dead config, and I've been hand-editing it out of every export before the YAML will compile.

This adds the same checkbox weather_icon was missing, using the same wording and the same mechanism as sensor_text:

- skip the HA sensor export when the box is ticked
- reference the entity id directly in the display lambda instead of `<entity>_txt`

Both changes are gated on `is_local_sensor`, which is undefined on every existing widget, so layouts that don't tick the box export exactly the same YAML as before. vitest passes unchanged (585 tests, 79 files), including the weather feature suites — they all exercise the Home Assistant path.

For what it's worth, the widget works nicely this way: Homey pushes a condition string like "partlycloudy" into a template text sensor and the icon mapping picks it up unchanged.
