### PR TITLE
Fix typo in graph widget body fill function

### DIFF
--- a/custom_components/esphome_designer/frontend/features/graph/exports_direct.js
+++ b/custom_components/esphome_designer/frontend/features/graph/exports_direct.js
@@ -58,7 +58,7 @@ export const exportDoc = (w, context) => {
     if (cond) lines.push(`        ${cond}`);
 
     if (bgColor) {
-        lines.push(`        it.fill_rectangle(${w.x}, ${w.y}, ${w.width}, ${w.height}, ${bgColor});`);
+        lines.push(`        it.filled_rectangle(${w.x}, ${w.y}, ${w.width}, ${w.height}, ${bgColor});`);
     }
 
     if (entityId) {

--- a/custom_components/esphome_designer/frontend/tests/features/graph_exports_direct.test.js
+++ b/custom_components/esphome_designer/frontend/tests/features/graph_exports_direct.test.js
@@ -79,7 +79,7 @@ describe('graph exports_direct', () => {
 
         const output = context.lines.join('\n');
         expect(output).toContain('if (id(graph_enabled)) {');
-        expect(output).toContain('it.fill_rectangle(0, 0, 100, 40, Color(white));');
+        expect(output).toContain('it.filled_rectangle(0, 0, 100, 40, Color(white));');
         expect(output).toContain('float g_pad = (g_max - g_min) * 0.05;');
         expect(output).toContain('int hist_count = id(hist_graph_2_count);');
         expect(output).toContain('it.line(x1, y1+1, x2, y2+1, Color(red));');


### PR DESCRIPTION
Fixes uncompilable YAML output when the graph widget has a color fill configured.  Corrects typo from fill_rectangle() to the correct filled_rectangle() call.  