### PR TITLE
Detect touchscreen support in custom hardware profiles

### DIFF
--- a/custom_components/esphome_designer/api/hardware.py
+++ b/custom_components/esphome_designer/api/hardware.py
@@ -114,6 +114,7 @@ class ReTerminalHardwareListView(DesignerBaseView):
                 height = 480
                 shape = "rect"
                 features: dict[str, Any] = {"psram": True, "lcd": True}
+                touch: dict[str, Any] | None = None
 
                 # Parse metadata from comments
                 name_match = re.search(r"#\s*Name:\s*(.*)", content, re.IGNORECASE)
@@ -194,6 +195,7 @@ class ReTerminalHardwareListView(DesignerBaseView):
                 else:
                     features["lvgl"] = True
 
+                data = None
                 try:
                     data = yaml.safe_load(content)
                     if data and "display" in data:
@@ -222,6 +224,29 @@ class ReTerminalHardwareListView(DesignerBaseView):
                 except Exception:  # noqa: BLE001
                     pass
 
+                # Detect touchscreen support so touch_area / nav widgets can export
+                touchscreen = (data or {}).get("touchscreen")
+                if isinstance(touchscreen, list) and touchscreen:
+                    touchscreen = touchscreen[0]
+                if isinstance(touchscreen, dict):
+                    touch_cfg = {
+                        key: touchscreen[key]
+                        for key in (
+                            "platform",
+                            "id",
+                            "i2c_id",
+                            "address",
+                            "interrupt_pin",
+                            "reset_pin",
+                            "transform",
+                            "calibration",
+                        )
+                        if key in touchscreen
+                    }
+                    if touch_cfg:
+                        features["touch"] = True
+                        touch = touch_cfg
+
                 clean_id = yaml_file.stem.replace("-", "_").replace(".", "_")
 
                 # Custom profiles get a prefix to avoid ID collisions with built-in
@@ -249,6 +274,7 @@ class ReTerminalHardwareListView(DesignerBaseView):
                     "shape": shape,
                     "chip": chip,
                     "board": board,
+                    "touch": touch,
                     "features": features
                 })
                 _LOGGER.debug("Loaded profile '%s' from %s", clean_id, yaml_file)

--- a/custom_components/esphome_designer/api/hardware.py
+++ b/custom_components/esphome_designer/api/hardware.py
@@ -225,7 +225,7 @@ class ReTerminalHardwareListView(DesignerBaseView):
                     pass
 
                 # Detect touchscreen support so touch_area / nav widgets can export
-                touchscreen = (data or {}).get("touchscreen")
+                touchscreen = (data if isinstance(data, dict) else {}).get("touchscreen")
                 if isinstance(touchscreen, list) and touchscreen:
                     touchscreen = touchscreen[0]
                 if isinstance(touchscreen, dict):

--- a/custom_components/esphome_designer/api/hardware.py
+++ b/custom_components/esphome_designer/api/hardware.py
@@ -264,7 +264,7 @@ class ReTerminalHardwareListView(DesignerBaseView):
                 else:
                     hw_package = f"hardware/{yaml_file.name}"
 
-                templates.append({
+                template: dict[str, Any] = {
                     "id": clean_id,
                     "name": name,
                     "isPackageBased": True,
@@ -274,9 +274,15 @@ class ReTerminalHardwareListView(DesignerBaseView):
                     "shape": shape,
                     "chip": chip,
                     "board": board,
-                    "touch": touch,
                     "features": features
-                })
+                }
+                # Only sent when a touchscreen was detected. mergeDeviceProfile
+                # spreads this template over the static profile, so a null here
+                # would erase a built-in profile's hand-written touch block.
+                if touch:
+                    template["touch"] = touch
+
+                templates.append(template)
                 _LOGGER.debug("Loaded profile '%s' from %s", clean_id, yaml_file)
 
             except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
Fixes #502.

## Problem

`onExportBinarySensors` in `frontend/features/touch_area/plugin.js` gates the entire touch export on `profile.touch`:

```javascript
if (!profile || !profile.touch) return;
```

Built-in profiles in `frontend/js/io/devices.js` declare that as a structured object alongside a `features.touch` flag:

```javascript
features: { psram: true, ..., touch: true },
touch: { platform: "gt911", transformed: true, transform: { swap_xy: true } }
```

Uploaded custom profiles never could, because `ReTerminalHardwareListView.get` in `api/hardware.py` doesn't look at the recipe's `touchscreen:` block and emits no `touch` key. `mergeDeviceProfile` spreads the backend template onto the profile, so `profile.touch` stays `undefined` and the exporter returns on its first line.

The result is that `touch_area` and `template_nav_bar` widgets silently export **no** `binary_sensor:` section on any custom profile. The widgets still render on the canvas and appear in the layout summary, and the generated YAML compiles and runs — it just does nothing when touched. There's no warning anywhere, which makes it hard to diagnose.

This gate sits in front of the RC35 `resolveTouchscreenId` change, so that fix doesn't help here — the exporter never runs far enough to resolve an ID.

## Change

Read the `touchscreen:` block from the YAML that's already being parsed, and populate both `features["touch"]` and a top-level `touch` object matching the built-in shape. Only the keys built-in profiles use are copied (`platform`, `id`, `i2c_id`, `address`, `interrupt_pin`, `reset_pin`, `transform`, `calibration`), so an unrecognised key in a recipe can't leak into the profile.

Inferring from the existing `touchscreen:` block means current custom recipes start working with no edits. A `# Touchscreen:` header field would also work and be more explicit, but would require every existing recipe to be updated — happy to switch if you'd prefer that.

`data` is now initialised to `None` before the parse, so a recipe whose YAML fails to load can't leave it unbound when the new block reads it.

## Testing

Verified against a LILYGO T5 4.7" E-paper V2.3 (ESP32-S3) custom profile with a GT911 on I2C. Before: no `binary_sensor:` section, touch areas emitted as lambda comments only, `change_page_to` generated with no caller. After: touch areas and nav bar export binary sensors bound to the profile's touchscreen ID, and page navigation works on the device.

Both list-form and mapping-form `touchscreen:` blocks are handled, and a recipe with no touchscreen is unaffected (`touch` stays `None`, exactly as today).